### PR TITLE
chore: Add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - main
+      - release-testing
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Should update changelog, tag commit, and create a github release
+          release-type: simple


### PR DESCRIPTION
Add release action. This should check commits to main for the string "release-as: X.X.X" and open a PR for the release, creating a changelog from our conventional commits.

When this is merged, it will add a git tag and github release pointing to the merged release PR.

I've made it also check the branch `release-testing` so that we can check if it works! After testing, I'll open a PR to get rid of this line