### PR TITLE
fix: Stop exiting interpreter on error

### DIFF
--- a/guppylang/error.py
+++ b/guppylang/error.py
@@ -1,5 +1,6 @@
 import ast
 import functools
+import os
 import sys
 import textwrap
 from collections.abc import Callable, Iterator, Sequence
@@ -212,8 +213,16 @@ def pretty_errors(f: FuncT) -> FuncT:
                 # reraised below) is not handled. However, when running tests, we have
                 # to manually invoke the hook to print the error message, since the
                 # tests always have to capture exceptions.
-                if "pytest" in sys.modules:
+                if _pytest_running():
                     hook(type(err), err, err.__traceback__)
                 raise
 
     return cast(FuncT, pretty_errors_wrapped)
+
+
+def _pytest_running() -> bool:
+    """Checks if we are currently running pytest.
+
+    See https://docs.pytest.org/en/latest/example/simple.html#pytest-current-test-environment-variable
+    """
+    return "PYTEST_CURRENT_TEST" in os.environ

--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -2,9 +2,7 @@ import importlib.util
 import pathlib
 import pytest
 
-from typing import Any
-from collections.abc import Callable
-
+from guppylang.error import GuppyError
 from guppylang.hugr import tys
 from guppylang.hugr.tys import TypeBound
 from guppylang.module import GuppyModule
@@ -17,7 +15,7 @@ def run_error_test(file, capsys):
     spec = importlib.util.spec_from_file_location("test_module", file)
     py_module = importlib.util.module_from_spec(spec)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(GuppyError):
         spec.loader.exec_module(py_module)
 
     err = capsys.readouterr().err


### PR DESCRIPTION
Instead, let the exception go through and use `sys.excepthook` to customise how the error message is printed.

Fixes #109